### PR TITLE
chore: update api version

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -3680,7 +3680,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simplelog",
- "socket2 0.5.10",
+ "socket2",
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
@@ -4133,16 +4133,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "socket2"
@@ -4779,7 +4769,7 @@ dependencies = [
  "mio 1.1.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,7 +38,7 @@ simplelog = "0.12"
 tauri-plugin-store = "2"
 tauri-plugin-autostart = "2.5.1"
 hostname = "0.4"
-socket2 = "0.5"
+socket2 = "0.6"
 
 [features]
 custom-protocol = []


### PR DESCRIPTION
## Summary by Sourcery

增强内容：
- 在 Tauri 项目的 manifest 中，将 `socket2` crate 依赖版本从 0.5 提升到 0.6。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Bump the socket2 crate dependency from 0.5 to 0.6 in the Tauri project manifest.

</details>