### PR TITLE
feat: Add timestamps to clipboard updates

### DIFF
--- a/src-tauri/src/runtime/clipboard.rs
+++ b/src-tauri/src/runtime/clipboard.rs
@@ -87,10 +87,7 @@ pub async fn start_clipboard_monitor(
                                     content_type: CONTENT_TYPE_TEXT.to_string(),
                                     data: text,
                                     sender_device_id: device_id.clone(),
-                                    timestamp: std::time::SystemTime::now()
-                                        .duration_since(std::time::UNIX_EPOCH)
-                                        .unwrap_or_default()
-                                        .as_secs(),
+                                    timestamp: current_timestamp(),
                                 },
                             };
                             let _ = tx.send(update);
@@ -146,10 +143,7 @@ pub async fn start_clipboard_monitor(
                                             content_type: CONTENT_TYPE_IMAGE_PNG.to_string(),
                                             data: b64,
                                             sender_device_id: device_id.clone(),
-                                            timestamp: std::time::SystemTime::now()
-                                                .duration_since(std::time::UNIX_EPOCH)
-                                                .unwrap_or_default()
-                                                .as_secs(),
+                                            timestamp: current_timestamp(),
                                         },
                                     };
                                     let _ = tx.send(update);
@@ -193,8 +187,10 @@ pub async fn start_clipboard_setter(
     events: mpsc::Sender<RuntimeEvent>,
     cancel: CancellationToken,
 ) {
-    let mut last_text = String::new();
-    let mut last_image_data = String::new();
+    let mut last_text: Option<String> = None;
+    let mut last_text_ts = 0;
+    let mut last_image_data: Option<String> = None;
+    let mut last_image_ts = 0;
     loop {
         tokio::select! {
             _ = cancel.cancelled() => break,
@@ -202,10 +198,11 @@ pub async fn start_clipboard_setter(
                 if let Some(payload) = maybe_payload {
                     match payload.content_type.as_str() {
                         CONTENT_TYPE_TEXT => {
-                            if payload.data == last_text {
+                            if payload.timestamp <= last_text_ts || Some(&payload.data) == last_text.as_ref() {
                                 continue;
                             }
-                            last_text = payload.data.clone();
+                            last_text_ts = payload.timestamp;
+                            last_text = Some(payload.data.clone());
                             if let Err(err) = set_text(&payload.data, disable_flag.clone()).await {
                                 let _ = events.send(RuntimeEvent::Log(RuntimeLogEvent::new(Level::Error, format!("设置文本剪贴板失败: {}", err)))).await;
                             } else {
@@ -214,10 +211,11 @@ pub async fn start_clipboard_setter(
                             }
                         }
                         CONTENT_TYPE_IMAGE_PNG => {
-                            if payload.data == last_image_data {
+                            if payload.timestamp <= last_image_ts || Some(&payload.data) == last_image_data.as_ref() {
                                 continue;
                             }
-                            last_image_data = payload.data.clone();
+                            last_image_ts = payload.timestamp;
+                            last_image_data = Some(payload.data.clone());
                             if let Err(err) = set_image_from_base64(&payload.data, disable_flag.clone()).await {
                                 let _ = events.send(RuntimeEvent::Log(RuntimeLogEvent::new(Level::Error, format!("设置图片剪贴板失败: {}", err)))).await;
                             } else {
@@ -307,6 +305,13 @@ fn read_clipboard_content() -> Result<ClipboardContent, String> {
     } else {
         Err("剪贴板没有可识别的内容".into())
     }
+}
+
+fn current_timestamp() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
 }
 
 fn encode_png(bytes: Vec<u8>, width: u32, height: u32) -> Result<Vec<u8>, String> {

--- a/src-tauri/src/runtime/clipboard.rs
+++ b/src-tauri/src/runtime/clipboard.rs
@@ -89,7 +89,7 @@ pub async fn start_clipboard_monitor(
                                     sender_device_id: device_id.clone(),
                                     timestamp: std::time::SystemTime::now()
                                         .duration_since(std::time::UNIX_EPOCH)
-                                        .unwrap()
+                                        .unwrap_or_default()
                                         .as_secs(),
                                 },
                             };
@@ -148,7 +148,7 @@ pub async fn start_clipboard_monitor(
                                             sender_device_id: device_id.clone(),
                                             timestamp: std::time::SystemTime::now()
                                                 .duration_since(std::time::UNIX_EPOCH)
-                                                .unwrap()
+                                                .unwrap_or_default()
                                                 .as_secs(),
                                         },
                                     };
@@ -193,18 +193,19 @@ pub async fn start_clipboard_setter(
     events: mpsc::Sender<RuntimeEvent>,
     cancel: CancellationToken,
 ) {
-    let mut last_timestamp = 0;
+    let mut last_text = String::new();
+    let mut last_image_data = String::new();
     loop {
         tokio::select! {
             _ = cancel.cancelled() => break,
             maybe_payload = rx.recv() => {
                 if let Some(payload) = maybe_payload {
-                    if payload.timestamp < last_timestamp {
-                        continue;
-                    }
-                    last_timestamp = payload.timestamp;
                     match payload.content_type.as_str() {
                         CONTENT_TYPE_TEXT => {
+                            if payload.data == last_text {
+                                continue;
+                            }
+                            last_text = payload.data.clone();
                             if let Err(err) = set_text(&payload.data, disable_flag.clone()).await {
                                 let _ = events.send(RuntimeEvent::Log(RuntimeLogEvent::new(Level::Error, format!("设置文本剪贴板失败: {}", err)))).await;
                             } else {
@@ -213,6 +214,10 @@ pub async fn start_clipboard_setter(
                             }
                         }
                         CONTENT_TYPE_IMAGE_PNG => {
+                            if payload.data == last_image_data {
+                                continue;
+                            }
+                            last_image_data = payload.data.clone();
                             if let Err(err) = set_image_from_base64(&payload.data, disable_flag.clone()).await {
                                 let _ = events.send(RuntimeEvent::Log(RuntimeLogEvent::new(Level::Error, format!("设置图片剪贴板失败: {}", err)))).await;
                             } else {

--- a/src-tauri/src/runtime/clipboard.rs
+++ b/src-tauri/src/runtime/clipboard.rs
@@ -188,7 +188,9 @@ pub async fn start_clipboard_setter(
     cancel: CancellationToken,
 ) {
     let mut last_text: Option<String> = None;
+    let mut last_text_ts = 0;
     let mut last_image_data: Option<String> = None;
+    let mut last_image_ts = 0;
     loop {
         tokio::select! {
             _ = cancel.cancelled() => break,
@@ -196,9 +198,10 @@ pub async fn start_clipboard_setter(
                 if let Some(payload) = maybe_payload {
                     match payload.content_type.as_str() {
                         CONTENT_TYPE_TEXT => {
-                            if Some(&payload.data) == last_text.as_ref() {
+                            if payload.timestamp <= last_text_ts || Some(&payload.data) == last_text.as_ref() {
                                 continue;
                             }
+                            last_text_ts = payload.timestamp;
                             last_text = Some(payload.data.clone());
                             if let Err(err) = set_text(&payload.data, disable_flag.clone()).await {
                                 let _ = events.send(RuntimeEvent::Log(RuntimeLogEvent::new(Level::Error, format!("设置文本剪贴板失败: {}", err)))).await;
@@ -208,9 +211,10 @@ pub async fn start_clipboard_setter(
                             }
                         }
                         CONTENT_TYPE_IMAGE_PNG => {
-                            if Some(&payload.data) == last_image_data.as_ref() {
+                            if payload.timestamp <= last_image_ts || Some(&payload.data) == last_image_data.as_ref() {
                                 continue;
                             }
+                            last_image_ts = payload.timestamp;
                             last_image_data = Some(payload.data.clone());
                             if let Err(err) = set_image_from_base64(&payload.data, disable_flag.clone()).await {
                                 let _ = events.send(RuntimeEvent::Log(RuntimeLogEvent::new(Level::Error, format!("设置图片剪贴板失败: {}", err)))).await;

--- a/src-tauri/src/runtime/clipboard.rs
+++ b/src-tauri/src/runtime/clipboard.rs
@@ -87,6 +87,10 @@ pub async fn start_clipboard_monitor(
                                     content_type: CONTENT_TYPE_TEXT.to_string(),
                                     data: text,
                                     sender_device_id: device_id.clone(),
+                                    timestamp: std::time::SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .unwrap()
+                                        .as_secs(),
                                 },
                             };
                             let _ = tx.send(update);
@@ -142,6 +146,10 @@ pub async fn start_clipboard_monitor(
                                             content_type: CONTENT_TYPE_IMAGE_PNG.to_string(),
                                             data: b64,
                                             sender_device_id: device_id.clone(),
+                                            timestamp: std::time::SystemTime::now()
+                                                .duration_since(std::time::UNIX_EPOCH)
+                                                .unwrap()
+                                                .as_secs(),
                                         },
                                     };
                                     let _ = tx.send(update);
@@ -185,11 +193,16 @@ pub async fn start_clipboard_setter(
     events: mpsc::Sender<RuntimeEvent>,
     cancel: CancellationToken,
 ) {
+    let mut last_timestamp = 0;
     loop {
         tokio::select! {
             _ = cancel.cancelled() => break,
             maybe_payload = rx.recv() => {
                 if let Some(payload) = maybe_payload {
+                    if payload.timestamp < last_timestamp {
+                        continue;
+                    }
+                    last_timestamp = payload.timestamp;
                     match payload.content_type.as_str() {
                         CONTENT_TYPE_TEXT => {
                             if let Err(err) = set_text(&payload.data, disable_flag.clone()).await {

--- a/src-tauri/src/runtime/clipboard.rs
+++ b/src-tauri/src/runtime/clipboard.rs
@@ -188,9 +188,7 @@ pub async fn start_clipboard_setter(
     cancel: CancellationToken,
 ) {
     let mut last_text: Option<String> = None;
-    let mut last_text_ts = 0;
     let mut last_image_data: Option<String> = None;
-    let mut last_image_ts = 0;
     loop {
         tokio::select! {
             _ = cancel.cancelled() => break,
@@ -198,10 +196,9 @@ pub async fn start_clipboard_setter(
                 if let Some(payload) = maybe_payload {
                     match payload.content_type.as_str() {
                         CONTENT_TYPE_TEXT => {
-                            if payload.timestamp <= last_text_ts || Some(&payload.data) == last_text.as_ref() {
+                            if Some(&payload.data) == last_text.as_ref() {
                                 continue;
                             }
-                            last_text_ts = payload.timestamp;
                             last_text = Some(payload.data.clone());
                             if let Err(err) = set_text(&payload.data, disable_flag.clone()).await {
                                 let _ = events.send(RuntimeEvent::Log(RuntimeLogEvent::new(Level::Error, format!("设置文本剪贴板失败: {}", err)))).await;
@@ -211,10 +208,9 @@ pub async fn start_clipboard_setter(
                             }
                         }
                         CONTENT_TYPE_IMAGE_PNG => {
-                            if payload.timestamp <= last_image_ts || Some(&payload.data) == last_image_data.as_ref() {
+                            if Some(&payload.data) == last_image_data.as_ref() {
                                 continue;
                             }
-                            last_image_ts = payload.timestamp;
                             last_image_data = Some(payload.data.clone());
                             if let Err(err) = set_image_from_base64(&payload.data, disable_flag.clone()).await {
                                 let _ = events.send(RuntimeEvent::Log(RuntimeLogEvent::new(Level::Error, format!("设置图片剪贴板失败: {}", err)))).await;
@@ -311,7 +307,7 @@ fn current_timestamp() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
-        .as_secs()
+        .as_millis() as u64
 }
 
 fn encode_png(bytes: Vec<u8>, width: u32, height: u32) -> Result<Vec<u8>, String> {

--- a/src-tauri/src/runtime/lan/discovery.rs
+++ b/src-tauri/src/runtime/lan/discovery.rs
@@ -143,9 +143,32 @@ pub async fn run_beacon_broadcaster(
                         .await;
 
                     // Attempt to rebind on network error
-                    if let Ok(new_socket) = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)).await {
-                        if new_socket.set_broadcast(true).is_ok() {
-                            socket = new_socket;
+                    match UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)).await {
+                        Ok(new_socket) => {
+                            if let Err(err) = new_socket.set_broadcast(true) {
+                                let _ = events
+                                    .send(RuntimeEvent::Log(RuntimeLogEvent::new(
+                                        Level::Error,
+                                        format!("LAN beacon rebind set_broadcast failed: {}", err),
+                                    )))
+                                    .await;
+                            } else {
+                                socket = new_socket;
+                                let _ = events
+                                    .send(RuntimeEvent::Log(RuntimeLogEvent::new(
+                                        Level::Info,
+                                        "LAN beacon rebind successful".to_string(),
+                                    )))
+                                    .await;
+                            }
+                        }
+                        Err(err) => {
+                            let _ = events
+                                .send(RuntimeEvent::Log(RuntimeLogEvent::new(
+                                    Level::Error,
+                                    format!("LAN beacon rebind failed: {}", err),
+                                )))
+                                .await;
                         }
                     }
                 }

--- a/src-tauri/src/runtime/lan/discovery.rs
+++ b/src-tauri/src/runtime/lan/discovery.rs
@@ -85,10 +85,7 @@ pub async fn run_beacon_broadcaster(
         discovery_port
     };
 
-    // Bind to INADDR_ANY so the OS picks the right interface.
-    // We use port 0 for the *sending* socket so we don't conflict with the
-    // listener that is bound to the same discovery port.
-    let socket = match UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)).await {
+    let mut socket = match UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)).await {
         Ok(s) => s,
         Err(e) => {
             let _ = events
@@ -141,9 +138,16 @@ pub async fn run_beacon_broadcaster(
                     let _ = events
                         .send(RuntimeEvent::Log(RuntimeLogEvent::new(
                             Level::Warn,
-                            format!("LAN beacon send failed: {}", e),
+                            format!("LAN beacon send failed (attempting rebind): {}", e),
                         )))
                         .await;
+
+                    // Attempt to rebind on network error
+                    if let Ok(new_socket) = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)).await {
+                        if new_socket.set_broadcast(true).is_ok() {
+                            socket = new_socket;
+                        }
+                    }
                 }
                 seq = seq.wrapping_add(1);
             }

--- a/src-tauri/src/runtime/lan/peer.rs
+++ b/src-tauri/src/runtime/lan/peer.rs
@@ -441,6 +441,7 @@ async fn run_peer_session(
                         let msg = PeerMessage::Clipboard {
                             content_type: update.payload.content_type.clone(),
                             data: update.payload.data.clone(),
+                            timestamp: update.payload.timestamp,
                         };
                         let frame = encode_peer_message(&msg);
                         let mut w = writer.lock().await;
@@ -490,10 +491,11 @@ async fn run_peer_session(
                             PeerMessage::Pong { .. } => {
                                 last_pong = Instant::now();
                             }
-                            PeerMessage::Clipboard { content_type, data } => {
+                            PeerMessage::Clipboard { content_type, data, timestamp } => {
                                 let payload = ClipboardBroadcastPayload {
                                     content_type: content_type.clone(),
                                     data,
+                                    timestamp,
                                 };
                                 let _ = tx_in.send(payload).await;
 

--- a/src-tauri/src/runtime/lan/protocol.rs
+++ b/src-tauri/src/runtime/lan/protocol.rs
@@ -100,6 +100,7 @@ pub enum PeerMessage {
     Clipboard {
         content_type: String,
         data: String,
+        timestamp: u64,
     },
 }
 

--- a/src-tauri/src/runtime/messages.rs
+++ b/src-tauri/src/runtime/messages.rs
@@ -39,6 +39,7 @@ pub struct ClipboardUpdatePayload {
     pub content_type: String,
     pub data: String,
     pub sender_device_id: String,
+    pub timestamp: u64,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -67,6 +68,7 @@ pub struct ClipboardBroadcast {
 pub struct ClipboardBroadcastPayload {
     pub content_type: String,
     pub data: String,
+    pub timestamp: u64,
 }
 
 // 客户端发送的消息结构


### PR DESCRIPTION
Add timestamps to clipboard updates

Include Unix timestamp in clipboard payloads and peer messages.
Make clipboard setter ignore incoming updates older than the last seen
timestamp to prevent applying stale clipboard contents.
When LAN beacon send fails, attempt to rebind a new UDP socket and set
broadcast before retrying.
close https://github.com/Dr1mH4X/RustSyncCV-Client/issues/13
## Summary by Sourcery

添加剪贴板时间戳，以防止应用过期的剪贴板内容，并在 UDP 发送失败时提升局域网广播信标的鲁棒性。

New Features:
- 在剪贴板更新负载和局域网对等端的剪贴板消息中加入 Unix 时间戳。

Bug Fixes:
- 在剪贴板设置器中忽略早于最近一次已应用时间戳的传入剪贴板更新，以避免回退到过期数据。
- 当局域网广播信标发送操作失败时，尝试重新绑定并重新配置 UDP 广播套接字，从而提高对瞬时网络错误的恢复能力。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add clipboard timestamps to prevent applying stale clipboard contents and improve LAN beacon robustness when UDP sends fail.

New Features:
- Include Unix timestamps in clipboard update payloads and LAN peer clipboard messages.

Bug Fixes:
- Ignore incoming clipboard updates older than the last applied timestamp in the clipboard setter to avoid reverting to stale data.
- Attempt to rebind and reconfigure the UDP broadcast socket when LAN beacon send operations fail, increasing resilience to transient network errors.

</details>

## Summary by Sourcery

为剪贴板添加时间戳用于新鲜度追踪，并改进局域网发现广播和剪贴板应用逻辑的健壮性。

New Features:
- 在剪贴板更新负载和局域网节点剪贴板消息中附加 Unix 时间戳，以追踪剪贴板数据的生成时间。

Bug Fixes:
- 在剪贴板设置器中通过追踪上一次已应用的内容，防止应用过期或重复的剪贴板文本和图像更新。
- 当发送操作失败时，通过重新绑定并重新配置 UDP 套接字以及记录重新绑定结果，提高局域网广播信标发送的鲁棒性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add clipboard timestamps for freshness tracking and improve robustness of LAN discovery beacons and clipboard application logic.

New Features:
- Attach Unix timestamps to clipboard update payloads and LAN peer clipboard messages to track when clipboard data was generated.

Bug Fixes:
- Prevent applying stale or duplicate clipboard text and image updates in the clipboard setter by tracking the last applied content.
- Increase resilience of LAN beacon broadcasting by rebinding and reconfiguring the UDP socket when send operations fail and logging rebind outcomes.

</details>

新功能：
- 在剪贴板更新负载和局域网节点的剪贴板消息中附加 Unix 时间戳，以指示剪贴板数据的生成时间。

错误修复：
- 通过忽略早于上次已应用时间戳的负载，或内容未变化的负载，防止应用过期或重复的文本和图像剪贴板更新。
- 在发送操作失败时，通过重新绑定和重新配置 UDP 广播套接字来提高局域网信标的弹性，并记录重新绑定的结果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为剪贴板添加时间戳用于新鲜度追踪，并改进局域网发现广播和剪贴板应用逻辑的健壮性。

New Features:
- 在剪贴板更新负载和局域网节点剪贴板消息中附加 Unix 时间戳，以追踪剪贴板数据的生成时间。

Bug Fixes:
- 在剪贴板设置器中通过追踪上一次已应用的内容，防止应用过期或重复的剪贴板文本和图像更新。
- 当发送操作失败时，通过重新绑定并重新配置 UDP 套接字以及记录重新绑定结果，提高局域网广播信标发送的鲁棒性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add clipboard timestamps for freshness tracking and improve robustness of LAN discovery beacons and clipboard application logic.

New Features:
- Attach Unix timestamps to clipboard update payloads and LAN peer clipboard messages to track when clipboard data was generated.

Bug Fixes:
- Prevent applying stale or duplicate clipboard text and image updates in the clipboard setter by tracking the last applied content.
- Increase resilience of LAN beacon broadcasting by rebinding and reconfiguring the UDP socket when send operations fail and logging rebind outcomes.

</details>

</details>

新功能：
- 为剪贴板更新载荷和局域网节点的剪贴板消息附加 Unix 时间戳，以跟踪剪贴板数据的新鲜度。

错误修复：
- 在剪贴板设置器中防止重新应用相同的剪贴板文本或图像数据，以避免冗余更新。
- 当局域网信标发送操作失败时，尝试重新绑定并重新配置 UDP 广播套接字，从而提高局域网发现的健壮性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为剪贴板添加时间戳用于新鲜度追踪，并改进局域网发现广播和剪贴板应用逻辑的健壮性。

New Features:
- 在剪贴板更新负载和局域网节点剪贴板消息中附加 Unix 时间戳，以追踪剪贴板数据的生成时间。

Bug Fixes:
- 在剪贴板设置器中通过追踪上一次已应用的内容，防止应用过期或重复的剪贴板文本和图像更新。
- 当发送操作失败时，通过重新绑定并重新配置 UDP 套接字以及记录重新绑定结果，提高局域网广播信标发送的鲁棒性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add clipboard timestamps for freshness tracking and improve robustness of LAN discovery beacons and clipboard application logic.

New Features:
- Attach Unix timestamps to clipboard update payloads and LAN peer clipboard messages to track when clipboard data was generated.

Bug Fixes:
- Prevent applying stale or duplicate clipboard text and image updates in the clipboard setter by tracking the last applied content.
- Increase resilience of LAN beacon broadcasting by rebinding and reconfiguring the UDP socket when send operations fail and logging rebind outcomes.

</details>

新功能：
- 在剪贴板更新负载和局域网节点的剪贴板消息中附加 Unix 时间戳，以指示剪贴板数据的生成时间。

错误修复：
- 通过忽略早于上次已应用时间戳的负载，或内容未变化的负载，防止应用过期或重复的文本和图像剪贴板更新。
- 在发送操作失败时，通过重新绑定和重新配置 UDP 广播套接字来提高局域网信标的弹性，并记录重新绑定的结果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为剪贴板添加时间戳用于新鲜度追踪，并改进局域网发现广播和剪贴板应用逻辑的健壮性。

New Features:
- 在剪贴板更新负载和局域网节点剪贴板消息中附加 Unix 时间戳，以追踪剪贴板数据的生成时间。

Bug Fixes:
- 在剪贴板设置器中通过追踪上一次已应用的内容，防止应用过期或重复的剪贴板文本和图像更新。
- 当发送操作失败时，通过重新绑定并重新配置 UDP 套接字以及记录重新绑定结果，提高局域网广播信标发送的鲁棒性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add clipboard timestamps for freshness tracking and improve robustness of LAN discovery beacons and clipboard application logic.

New Features:
- Attach Unix timestamps to clipboard update payloads and LAN peer clipboard messages to track when clipboard data was generated.

Bug Fixes:
- Prevent applying stale or duplicate clipboard text and image updates in the clipboard setter by tracking the last applied content.
- Increase resilience of LAN beacon broadcasting by rebinding and reconfiguring the UDP socket when send operations fail and logging rebind outcomes.

</details>

</details>

</details>